### PR TITLE
Fixed clang-format and Added format for empty argument function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tags
 dist/
 build/
 docs/build/
+
+/.venv

--- a/c_formatter_42/data/.clang-format
+++ b/c_formatter_42/data/.clang-format
@@ -73,12 +73,12 @@ AlwaysBreakBeforeMultilineStrings: false
 
 # BinPackArguments (bool)
 # If false, a function call’s arguments will either be all on the same line or will have one line each.
-BinPackArguments: true
+BinPackArguments: false
 
 
 # BinPackParameters (bool)
 # If false, a function declaration’s or function definition’s parameters will either all be on the same line or will have one line each.
-BinPackParameters: true
+BinPackParameters: false
 
 # BreakBeforeBraces (BraceBreakingStyle)
 # The brace breaking style to use.

--- a/c_formatter_42/formatters/misc.py
+++ b/c_formatter_42/formatters/misc.py
@@ -55,3 +55,11 @@ def remove_multiline_condition_space(content: str) -> str:
         lambda match: "{}\t{}".format(match.group("tabs"), match.group("rest")),
         content,
     )
+
+
+def insert_void(content: str) -> str:
+    return re.sub(
+        r"(?P<funcdef>[0-9a-zA-Z_]*\t+[0-9a-zA-Z_]*\s*)\(\s*\)",
+        lambda match: "{}({})".format(match.group("funcdef"), "void"),
+        content,
+    )

--- a/c_formatter_42/run.py
+++ b/c_formatter_42/run.py
@@ -18,12 +18,13 @@ from c_formatter_42.formatters.return_type_single_tab import return_type_single_
 from c_formatter_42.formatters.misc import (
     parenthesize_return,
     space_before_semi_colon,
-    remove_multiline_condition_space
+    remove_multiline_condition_space,
+    insert_void,
 )
 
 
 def run_all(content: str) -> str:
-    """ Run all formatters """
+    """Run all formatters"""
     content = clang_format(content)
     content = preprocessor_directive(content)
     content = remove_multiline_condition_space(content)
@@ -32,4 +33,5 @@ def run_all(content: str) -> str:
     content = hoist(content)
     content = align(content)
     content = return_type_single_tab(content)
+    content = insert_void(content)
     return content

--- a/tests/formatters/test_misc.py
+++ b/tests/formatters/test_misc.py
@@ -14,6 +14,7 @@ from c_formatter_42.formatters.misc import (
     parenthesize_return,
     space_before_semi_colon,
     remove_multiline_condition_space,
+    insert_void,
 )
 
 
@@ -80,3 +81,11 @@ while (input != NULL && input->tag & TAG_IS_STR &&
 \t\tinput->next != NULL && input->next->tag & TAG_IS_STR)
     """
     assert output == remove_multiline_condition_space(input)
+
+
+def test_insert_void():
+    assert "int main()" == insert_void("int main()")
+    assert "void func  ( )" == insert_void("void func  ( )")
+    assert "int	main(void)" == insert_void("int	main()")
+    assert "void	func  (void)" == insert_void("void	func  ( )")
+    assert "void		func  (void)" == insert_void("void		func  ( )")


### PR DESCRIPTION
The values of the keys I deleted in #2 were not the same as the duplicated ones', and it caused incorrect format by the clang-format. Now I've fixed the values.

Also I added a format function to deal with Norm v3 II.3.